### PR TITLE
Added saving certificates for reusing

### DIFF
--- a/sidecar/docker-compose.yml
+++ b/sidecar/docker-compose.yml
@@ -16,6 +16,7 @@ services:
    image: jrcs/letsencrypt-nginx-proxy-companion
    volumes:
     - "/var/run/docker.sock:/var/run/docker.sock:ro"
+    - "./acme:/etc/acme.sh"
    volumes_from:
     - "nginx-proxy"
 


### PR DESCRIPTION
While you have a lot of sites and restart your containers often, you have this error:

Register account Error: {
  "type": "urn:ietf:params:acme:error:rateLimited",
  "detail": "Error creating new account :: too many registrations for this IP: see https://letsencrypt.org/docs/rate-limits/",
  "status": 429
}

This is related with letsencrypt-nginx-proxy-companion v.2 issue discussed here https://github.com/nextcloud/docker/pull/1358

The problem can be fixed literally by adding 1 row to the config - so all certificates will be saved in external volumes and won't be lost after each container stop/restart.